### PR TITLE
Add username to package name for GitHub Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "event-driven-dynamodb-rules-engine",
+  "name": "@Rooster212/event-driven-dynamodb-rules-engine",
   "version": "0.1.0",
   "description": "Events and rules engine for use with DynamoDB.",
   "main": "dist/index.js",


### PR DESCRIPTION
GitHub packages requires the organization or username as part of the name of the package for publishing.