### PR TITLE
Update stream lambda to work with changed item layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-dynamodb": "3.154.0",
         "@aws-sdk/client-eventbridge": "3.154.0",
         "@aws-sdk/lib-dynamodb": "3.154.0",
+        "@aws-sdk/util-dynamodb": "3.154.0",
         "aws-lambda": "^1.0.7"
       },
       "devDependencies": {
@@ -22,6 +23,8 @@
         "@typescript-eslint/parser": "^4.17.0",
         "aws-cdk": "^2.34.2",
         "aws-cdk-lib": "^2.34.2",
+        "aws-sdk-client-mock": "^2.0.0",
+        "aws-sdk-client-mock-jest": "^2.0.0",
         "constructs": "^10.1.63",
         "esbuild": "^0.14.51",
         "eslint": "^7.21.0",
@@ -2400,6 +2403,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
@@ -2595,6 +2615,21 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
       "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -3199,6 +3234,52 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-2.0.0.tgz",
+      "integrity": "sha512-yjC39Ud78Cgwu9jLc7LoFILT8xtyvR9doCfd8tjeqaOI4oQ5IeTaIYDezWpWKndmrjXZzVLw/odWKP1hpuvsVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock-jest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-2.0.0.tgz",
+      "integrity": "sha512-HwJeJThngXDUyyyd3Hk12Ailu3smhQzyox+nrF14TxE/LNSJsSmJ2rXahzj7Zdyxn9jDSe2h2ulrfUNYgbPYlw==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "^28.1.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "aws-sdk-client-mock": "2.0.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock-jest/node_modules/@types/jest": {
+      "version": "28.1.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+      "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock-jest/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/aws-sdk-client-mock/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "28.1.3",
@@ -5637,6 +5718,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5677,6 +5764,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -5804,6 +5897,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5979,6 +6085,21 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -6287,6 +6408,42 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6434,9 +6591,9 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9015,6 +9172,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
@@ -9194,6 +9368,21 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
       "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -9589,6 +9778,53 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      }
+    },
+    "aws-sdk-client-mock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-2.0.0.tgz",
+      "integrity": "sha512-yjC39Ud78Cgwu9jLc7LoFILT8xtyvR9doCfd8tjeqaOI4oQ5IeTaIYDezWpWKndmrjXZzVLw/odWKP1hpuvsVQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "aws-sdk-client-mock-jest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-2.0.0.tgz",
+      "integrity": "sha512-HwJeJThngXDUyyyd3Hk12Ailu3smhQzyox+nrF14TxE/LNSJsSmJ2rXahzj7Zdyxn9jDSe2h2ulrfUNYgbPYlw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "^28.1.3",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@types/jest": {
+          "version": "28.1.8",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+          "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
+          "dev": true,
+          "requires": {
+            "expect": "^28.0.0",
+            "pretty-format": "^28.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
       }
     },
     "babel-jest": {
@@ -11334,6 +11570,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -11365,6 +11607,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.memoize": {
@@ -11470,6 +11718,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11600,6 +11861,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -11804,6 +12082,37 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11914,9 +12223,9 @@
       "dev": true
     },
     "supports-color": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rooster212/event-driven-dynamodb-rules-engine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rooster212/event-driven-dynamodb-rules-engine",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.154.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rooster212/event-driven-dynamodb-rules-engine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Events and rules engine for use with DynamoDB.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/client-dynamodb": "3.154.0",
     "@aws-sdk/client-eventbridge": "3.154.0",
     "@aws-sdk/lib-dynamodb": "3.154.0",
+    "@aws-sdk/util-dynamodb": "3.154.0",
     "aws-lambda": "^1.0.7"
   },
   "devDependencies": {
@@ -39,6 +40,8 @@
     "@typescript-eslint/parser": "^4.17.0",
     "aws-cdk": "^2.34.2",
     "aws-cdk-lib": "^2.34.2",
+    "aws-sdk-client-mock": "^2.0.0",
+    "aws-sdk-client-mock-jest": "^2.0.0",
     "constructs": "^10.1.63",
     "esbuild": "^0.14.51",
     "eslint": "^7.21.0",

--- a/src/integration-test-helpers.ts
+++ b/src/integration-test-helpers.ts
@@ -61,7 +61,11 @@ const createLocalTable = async (): Promise<DB> => {
 
   return {
     name: tableName,
-    client: DynamoDBDocumentClient.from(ddb),
+    client: DynamoDBDocumentClient.from(ddb, {
+      marshallOptions: {
+        convertEmptyValues: true,
+      },
+    }),
     delete: deleteTableFunc,
   };
 };

--- a/stream/onDynamoDBStreamEvent.test.ts
+++ b/stream/onDynamoDBStreamEvent.test.ts
@@ -1,0 +1,240 @@
+import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { DynamoDBStreamEvent } from "aws-lambda";
+import {
+  createOnDynamoDBStreamHandler,
+  OnDynamoDBStreamEventLogFunc,
+} from "./onDynamoDBStreamEvent";
+import { mockClient } from "aws-sdk-client-mock";
+import "aws-sdk-client-mock-jest";
+
+const testDynamoDBStreamEventInvalid: DynamoDBStreamEvent = {
+  Records: [
+    {
+      eventID: "1",
+      eventName: "INSERT",
+      eventVersion: "1.0",
+      eventSource: "aws:dynamodb",
+      awsRegion: "us-east-1",
+      dynamodb: {
+        Keys: {
+          Id: {
+            N: "101",
+          },
+        },
+        NewImage: {
+          Message: {
+            S: "New item!",
+          },
+          Id: {
+            N: "101",
+          },
+        },
+        SequenceNumber: "111",
+        SizeBytes: 26,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+      eventSourceARN: "stream-ARN",
+    },
+    {
+      eventID: "2",
+      eventName: "MODIFY",
+      eventVersion: "1.0",
+      eventSource: "aws:dynamodb",
+      awsRegion: "us-east-1",
+      dynamodb: {
+        Keys: {
+          Id: {
+            N: "101",
+          },
+        },
+        NewImage: {
+          Message: {
+            S: "This item has changed",
+          },
+          Id: {
+            N: "101",
+          },
+        },
+        OldImage: {
+          Message: {
+            S: "New item!",
+          },
+          Id: {
+            N: "101",
+          },
+        },
+        SequenceNumber: "222",
+        SizeBytes: 59,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+      eventSourceARN: "stream-ARN",
+    },
+  ],
+};
+
+const testDynamoDBStreamEventValid: DynamoDBStreamEvent = {
+  Records: [
+    {
+      eventID: "1",
+      eventName: "INSERT",
+      eventVersion: "1.0",
+      eventSource: "aws:dynamodb",
+      awsRegion: "us-east-1",
+      dynamodb: {
+        Keys: {
+          _id: {
+            S: "ACCOUNT/abc123abc123",
+          },
+          _rng: {
+            S: "OUTBOUND/AccountCreated",
+          },
+        },
+        NewImage: {
+          _id: {
+            S: "ACCOUNT/abc123abc123",
+          },
+          _rng: {
+            S: "OUTBOUND/AccountCreated",
+          },
+          _facet: {
+            S: "ACCOUNT",
+          },
+          _typ: {
+            S: "AccountCreated",
+          },
+          _ts: {
+            N: "1234567890",
+          },
+          _date: {
+            S: new Date().toISOString(),
+          },
+          _seq: {
+            N: "1",
+          },
+          accountId: {
+            S: "abc123abc123",
+          },
+          balance: {
+            N: "51235",
+          },
+        },
+        SequenceNumber: "111",
+        SizeBytes: 26,
+        StreamViewType: "NEW_AND_OLD_IMAGES",
+      },
+      eventSourceARN: "stream-ARN",
+    },
+  ],
+};
+
+const mockEventBridgeClient = mockClient(EventBridgeClient);
+
+describe("onDynamoDBStreamEvent", () => {
+  beforeEach(() => {
+    mockEventBridgeClient.resetHistory();
+    process.env.CONFIGURED_EVENT_SOURCE = "abc123";
+    process.env.PUBLISH_TO_EVENT_BUS_NAME = "my-event-bus";
+  });
+
+  afterAll(() => {
+    delete process.env.CONFIGURED_EVENT_SOURCE;
+    delete process.env.PUBLISH_TO_EVENT_BUS_NAME;
+  });
+
+  it("successfully writes the expected events", async () => {
+    mockEventBridgeClient.on(PutEventsCommand).resolves({
+      Entries: [
+        {
+          EventId: "0",
+        },
+        {
+          EventId: "1",
+        },
+      ],
+    });
+
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await handler(testDynamoDBStreamEventValid);
+
+    expect(testLogger).toBeCalledWith("processing records", { count: 1 });
+    expect(mockEventBridgeClient).toHaveReceivedCommandTimes(PutEventsCommand, 1);
+    expect(mockEventBridgeClient).toHaveReceivedCommandWith(PutEventsCommand, {
+      Entries: [
+        {
+          EventBusName: "my-event-bus",
+          Source: "abc123",
+          DetailType: "AccountCreated",
+          Detail: JSON.stringify({
+            accountId: "abc123abc123",
+            balance: 51235,
+          }),
+        },
+      ],
+    });
+  });
+
+  it("processes no records if the records are not valid", async () => {
+    mockEventBridgeClient.on(PutEventsCommand).rejects();
+
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await handler(testDynamoDBStreamEventInvalid);
+
+    expect(testLogger).toBeCalledWith("processing records", { count: 2 });
+    expect(mockEventBridgeClient).toHaveReceivedCommandTimes(PutEventsCommand, 0);
+  });
+
+  it("throws an error when an exception occurs sending an event", async () => {
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+
+    mockEventBridgeClient.on(PutEventsCommand).rejects(new Error("woops"));
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await expect(handler(testDynamoDBStreamEventValid)).rejects.toThrowError();
+    expect(testLogger).toBeCalledWith("processing records", { count: 1 });
+    expect(mockEventBridgeClient).toHaveReceivedCommandTimes(PutEventsCommand, 1);
+  });
+
+  it("throws an error when errors are returned for sending an event", async () => {
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+
+    mockEventBridgeClient.on(PutEventsCommand).resolves({
+      Entries: [
+        {
+          ErrorCode: "1",
+          ErrorMessage: "Failed!",
+        },
+      ],
+    });
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await expect(handler(testDynamoDBStreamEventValid)).rejects.toThrowError(new Error("Failed!"));
+    expect(testLogger).toBeCalledWith("processing records", { count: 1 });
+    expect(mockEventBridgeClient).toHaveReceivedCommandTimes(PutEventsCommand, 1);
+  });
+
+  it("throws an error if the configured event source is not set", async () => {
+    delete process.env.CONFIGURED_EVENT_SOURCE;
+
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await expect(handler(testDynamoDBStreamEventValid)).rejects.toThrowError(
+      new Error("CONFIGURED_EVENT_SOURCE is not set"),
+    );
+  });
+
+  it("throws an error if the event bus to publish to is not set", async () => {
+    delete process.env.PUBLISH_TO_EVENT_BUS_NAME;
+
+    const testLogger: OnDynamoDBStreamEventLogFunc = jest.fn();
+    const handler = createOnDynamoDBStreamHandler(testLogger);
+
+    await expect(handler(testDynamoDBStreamEventValid)).rejects.toThrowError(
+      new Error("PUBLISH_TO_EVENT_BUS_NAME is not set"),
+    );
+  });
+});


### PR DESCRIPTION
With the last change where I updated the DynamoDB layout to be flat rather than containing all fields within an `_itm` field (which would allow for secondary GSIs/LSIs) I forgot to update the DynamoDB stream Lambda.

This fixes the Lambda to support this new layout, as well as adding tests to cover the Lambda.